### PR TITLE
enable ARM Linux GitHub Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         java: [ '11',  '17', '21' ]
         jdk: [ 'temurin' ]
-        os: [ 'ubuntu-22.04' ]
+        os: [ 'ubuntu-22.04', 'ubuntu-22.04-arm' ]
     runs-on: ${{ matrix.os }}
     name: Java ${{ matrix.java }} ${{ matrix.os }}
     if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

